### PR TITLE
Avoid undefined on array.length when null array assigned

### DIFF
--- a/js/angular-tablesort.js
+++ b/js/angular-tablesort.js
@@ -139,6 +139,7 @@ tableSortModule.directive("tsRepeat", function() {
 
 tableSortModule.filter( 'tablesortOrderBy', function(){
     return function(array, sortfun ) {
+        if(!array) return;
         var arrayCopy = [];
         for ( var i = 0; i < array.length; i++) { arrayCopy.push(array[i]); }
         return arrayCopy.sort( sortfun );


### PR DESCRIPTION
When a null array is assigned to the ng-repeat this causes a js error
