### PR TITLE
Make Tablesort work in Internet Explorer 9 by using DOM manipulation rather than .html() for replacing tr content.

### DIFF
--- a/js/angular-tablesort.js
+++ b/js/angular-tablesort.js
@@ -172,7 +172,13 @@ tableSortModule.directive("tsRepeat", ['$compile', function($compile) {
             repeatExpr = repeatExpr.replace(/^\s*([\s\S]+?)\s+in\s+([\s\S]+?)(\s+track\s+by\s+[\s\S]+?)?\s*$/,
                 "$1 in $2 | tablesortOrderBy:sortFun$3");
 
-            element.html("<td colspan='"+tdcount+"'></td>");
+            while (element[0].firstChild) {
+              element[0].removeChild(element[0].firstChild);
+            }
+            var td = document.createElement("td");
+            td.colSpan=tdcount;
+            element[0].appendChild(td);
+
             element[0].className += " showIfLast";
             clone.removeAttr("ts-repeat");
 


### PR DESCRIPTION
Angular tablesort fails hard in Internet Explorer 9 due to a "Invalid target element for this operation" error, originating from the "element.html()" call.

This patch replaces the html() call with a DOM operation which works in older versions of Internet Explorer as well as modern browsers.
