### PR TITLE
Allow installing with npm

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,0 +1,11 @@
+{
+  "name": "angular-tablesort",
+  "version": "1.0.6",
+  "description": "Sort angularjs tables easily",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/tamlyn/angular-tablesort.git"
+  },
+  "license": "MIT",
+  "homepage": "https://github.com/tamlyn/angular-tablesort"
+}


### PR DESCRIPTION
npm is increasingly replacing Bower for front-end dependency management. The `package.json` allows this module to be installed with `npm install mattiash/angular-tablesort`. 