### PR TITLE
Fixes #36 - Adding "ignore" element to bower.json

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -5,5 +5,6 @@
   "main": ["./js/angular-tablesort.js"],
   "dependencies": {
     "angular": "*"
-  }
+  },
+  "ignore": []
 }

--- a/package.json
+++ b/package.json
@@ -7,6 +7,5 @@
     "url": "https://github.com/mattiash/angular-tablesort.git"
   },
   "license": "MIT",
-  "homepage": "https://github.com/mattiash/angular-tablesort",
-  "ignore": []
+  "homepage": "https://github.com/mattiash/angular-tablesort"
 }

--- a/package.json
+++ b/package.json
@@ -7,5 +7,6 @@
     "url": "https://github.com/mattiash/angular-tablesort.git"
   },
   "license": "MIT",
-  "homepage": "https://github.com/mattiash/angular-tablesort"
+  "homepage": "https://github.com/mattiash/angular-tablesort",
+  "ignore": []
 }


### PR DESCRIPTION
This Addition to the package.json prevents the following warning to appear during install through bower

```
bower angular-tablesort#master     invalid-meta angular-tablesort is missing "ignore" entry in bower.json
```