### PR TITLE
Feature/notification

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,6 +68,8 @@ The `ts-wrapper` attribute must be set on element that surrounds both the headin
 
 The `ts-criteria` attribute tells tablesort which expression it should sort on when that element is clicked. Normally, the ts-criteria is the same as the expression that is shown in the column, but it doesn't have to be. The ts-criteria can also be filtered using the normal AngularJS filter syntax. Tablesort includes two filters parseInt and parseFloat that use the javascript functions of the same name, but any filter can be used.
 
+The `ts-name` attribute can be set to declare a unique name for an expression which will be used in the event fired when sorting has changed.
+
 The `ts-default` attribute can be set on one or more columns to sort on them in ascending order by default.
 To sort in descending order, set ts-default to "descending"
 
@@ -105,6 +107,22 @@ This will first sort the rows according to your specification and then only show
 
 If the `ng-repeat` expression contains a `track by` statement (which is generally a good idea), that expression will
 be used to provide a [stable](http://en.wikipedia.org/wiki/Sorting_algorithm#Stability) sort result.
+
+
+Events
+------
+
+When changing sorting in the table, an event named `tablesort:sortOrder` will be emitted which contains an array of all current sorting definitions.
+These sorting definitions could be used to set up sorted data retrieval when using other directives that handle things like pagination or filtering.
+
+```js
+$scope.$on('tablesort:sortOrder', (event, sortOrder) => {
+  self.sortOrder = sortOrder.map(o => {
+   return `${o.name} ${o.order ? 'ASC' : 'DESC'}`;
+  });
+});
+```
+
 
 
  CSS

--- a/example-advanced.html
+++ b/example-advanced.html
@@ -140,6 +140,28 @@
                 </tr>
             </tbody>
         </table>
+        <hr />
+
+        <h2>With special event names and no pagination (see console for events)</small></h2>
+        <table class="table table-striped" ts-wrapper>
+            <thead>
+                <tr>
+                    <th ts-criteria="Id" ts-name="id">Id</th>
+                    <th ts-criteria="Name|lowercase" ts-name="name" ts-default>Name</th>
+                    <th ts-criteria="Price|parseFloat" ts-name="price">Price</th>
+                    <th ts-criteria="Quantity|parseInt" ts-name="quantity">Quantity</th>
+                </tr>
+            </thead>
+            <tbody>
+                <tr ng-repeat="item in tableFiveItems track by item.Id"
+                    ts-repeat>
+                    <td>{{item.Id}}</td>
+                    <td>{{item.Name}}</td>
+                    <td>{{item.Price | currency}}</td>
+                    <td>{{item.Quantity}}</td>
+                </tr>
+            </tbody>
+        </table>
 
         <hr />
 
@@ -200,11 +222,15 @@
     angular
         .module( 'myApp', ['tableSort', 'ui.bootstrap'] )
         .controller( "tableTestCtrl", function tableTestCtrl($scope)  {
+          $scope.$on('tablesort:sortOrder', (event, sortOrder) => {
+            console.log('tablesort:sortOrder event', sortOrder);
+          });
             //Generate some fake data
             $scope.tableOneItems = getFakeData(10000);
             $scope.tableTwoItems = getFakeData(100);
             $scope.tableThreeItems = getFakeData(12);
             $scope.tableFourItems = getFakeData(100);
+            $scope.tableFiveItems = getFakeData(20);
 
             $scope.customPerPageOptions = [20,40,60];
             $scope.customPerPageDefault = 40;

--- a/js/angular-tablesort.js
+++ b/js/angular-tablesort.js
@@ -80,15 +80,13 @@ tableSortModule.directive('tsWrapper', ['$parse', '$compile', function( $parse, 
             $scope.sortExpression = [];
             $scope.headings = [];
 
-            //Private vars
-            var parse_sortexpr = function( expr ) {
-                return [$parse( expr ), null, false];
+            var parse_sortexpr = function( expr, name ) {
+                return [$parse( expr ), null, false, name ? name : expr];
             };
 
-            //Public directive vars for the other directives that depend on this
-            this.setSortField = function( sortexpr, element ) {
+            this.setSortField = function( sortexpr, element, name ) {
                 var i;
-                var expr = parse_sortexpr( sortexpr );
+                var expr = parse_sortexpr( sortexpr, name );
                 if( $scope.sortExpression.length === 1
                     && $scope.sortExpression[0][0] === expr[0] ) {
                     if( $scope.sortExpression[0][2] ) {
@@ -101,6 +99,10 @@ tableSortModule.directive('tsWrapper', ['$parse', '$compile', function( $parse, 
                         element.addClass( "tablesort-desc" );
                         $scope.sortExpression[0][2] = true;
                     }
+                    $scope.$emit('tablesort:sortOrder', [{
+                      name: $scope.sortExpression[0][3],
+                      order: $scope.sortExpression[0][2]
+                    }]);
                 }
                 else {
                     for( i=0; i<$scope.headings.length; i=i+1 ) {
@@ -110,13 +112,17 @@ tableSortModule.directive('tsWrapper', ['$parse', '$compile', function( $parse, 
                     }
                     element.addClass( "tablesort-asc" );
                     $scope.sortExpression = [expr];
+                    $scope.$emit('tablesort:sortOrder', [{
+                      name: expr[3],
+                      order: expr[2]
+                    }]);
                 }
             };
 
-            this.addSortField = function( sortexpr, element ) {
+            this.addSortField = function( sortexpr, element, name ) {
                 var i;
                 var toggle_order = false;
-                var expr = parse_sortexpr( sortexpr );
+                var expr = parse_sortexpr( sortexpr, name );
                 for( i=0; i<$scope.sortExpression.length; i=i+1 ) {
                     if( $scope.sortExpression[i][0] === expr[0] ) {
                         if( $scope.sortExpression[i][2] ) {
@@ -136,6 +142,14 @@ tableSortModule.directive('tsWrapper', ['$parse', '$compile', function( $parse, 
                     element.addClass( "tablesort-asc" );
                     $scope.sortExpression.push( expr );
                 }
+
+                $scope.$emit('tablesort:sortOrder', $scope.sortExpression.map(function (a) {
+                  return {
+                    name: a[3],
+                    order: a[2]
+                  };
+                }));
+
             };
 
             this.setTrackBy = function( trackBy ) {
@@ -346,19 +360,19 @@ tableSortModule.directive('tsCriteria', function() {
             var clickingCallback = function(event) {
                 scope.$apply( function() {
                     if( event.shiftKey ) {
-                        tsWrapperCtrl.addSortField(attrs.tsCriteria, element);
+                        tsWrapperCtrl.addSortField(attrs.tsCriteria, element, attrs.tsName);
                     }
                     else {
-                        tsWrapperCtrl.setSortField(attrs.tsCriteria, element);
+                        tsWrapperCtrl.setSortField(attrs.tsCriteria, element, attrs.tsName);
                     }
                 } );
             };
             element.bind('click', clickingCallback);
             element.addClass('tablesort-sortable');
             if( "tsDefault" in attrs && attrs.tsDefault !== "0" ) {
-                tsWrapperCtrl.addSortField( attrs.tsCriteria, element );
+                tsWrapperCtrl.addSortField( attrs.tsCriteria, element, attrs.tsName );
                 if( attrs.tsDefault === "descending" ) {
-                    tsWrapperCtrl.addSortField( attrs.tsCriteria, element );
+                    tsWrapperCtrl.addSortField( attrs.tsCriteria, element, attrs.tsName );
                 }
             }
             if( "tsFilter" in attrs) {


### PR DESCRIPTION
This to allow pagination/infinite scroll of sorted tables

The added "ts-name" parameter is to allow unambiguous declaration of a remote linked name

Sadly this request was forgotten as the gigantic pagination PR took precedence; but the functionality is really needed for infinite scrolling etc... (not everyone uses pagination).