### PR TITLE
Improved page range display

### DIFF
--- a/js/angular-tablesort.js
+++ b/js/angular-tablesort.js
@@ -60,9 +60,11 @@ tableSortModule.directive('tsWrapper', ['$parse', '$compile', function( $parse, 
                 getPageRangeString: function(total) {
                     //TODO: Format these numbers, perhaps optionally
                     var maxOnPage = total !== $scope.filtering.filteredCount ? $scope.filtering.filteredCount : total;
-                    var startPage = ($scope.pagination.currentPage - 1) * ($scope.pagination.perPage + 1);
+                    //This keeps the first page labeled as 1, not 0
+                    var startPage = Math.max(($scope.pagination.currentPage - 1) * ($scope.pagination.perPage + 1), 1);
                     var endPage = Math.min($scope.pagination.currentPage * $scope.pagination.perPage, maxOnPage);
-                    return $scope.filtering.filteredCount === 0 ? "" : (startPage > 0 ? startPage + "-" : "") + endPage;
+                    //This prevents the range from showing when the total number of items can be shown on a single page
+                    return $scope.filtering.filteredCount === 0 ? "" : (endPage === maxOnPage && startPage === 1 ? "" : startPage + "-") + endPage;
                 }
             };
 


### PR DESCRIPTION
This is a small tweak to improve the display text for the "current page range" display.  Before it would not show the `1-` prefix when on the first page, but it would on any other page.  Now it will always show that prefix unless the total number of displayed items fits on a single page.

| Page | Text Before                                                     | Text After                                                     | Notes                                |
|---|----------------------------------------------------------|-------------------------------------------------------|-------------------------|
| **1** | "Showing 25 of 92 items"                                  | "Showing 1-25 of 92 items"                            | _prefix added_ |
| **2** | "Showing 26-50 of 92 items"                             | "Showing 26-50 of 92 items"                            | _no change_ |
| **1** | "Showing 25 of 38 items (filtered from 92)"       | "Showing 1-25 of 38 items (filtered from 92)" | _prefix added_ |
| **2** | "Showing 26-38 of 38 items (filtered from 92)" | "Showing 26-38 of 38 items (filtered from 92)" | _no change_ |
| **1** | "Showing 5 of 5 items (filtered from 92)"           | "Showing 5 of 5 items (filtered from 92)"          | _no change_ |