### PR TITLE
Get sorted/filtered/paged data out of the table

### DIFF
--- a/README.md
+++ b/README.md
@@ -339,3 +339,28 @@ $scope.customFilterFn = function(item){
     </tbody>
 </table>
 ```
+
+###Getting Data Out of the Table
+
+To get the current view of the data in the table, pass something to the `ts-get-table-data-function` attribute.  Whatever is passed in will be converted into a function.
+That function can then be passed as a parameter to a click event function, or anything else.  Within the controller, just run that function and it will return the data in the table.
+
+```html
+<button type="button" ng-click="getTableData(getDataFn)">Get the table data</button>
+
+<table ts-wrapper ts-get-table-data-function="getDataFn">
+```
+
+In the above example, the click function `ng-click="getTableData(getDataFn)"` would be handled like this:
+
+```js
+$scope.getTableData = function (getDataFn) {
+    var results = getDataFn(true, true, false);
+    console.log("data from table", results)
+};
+```
+
+When running the `getDataFn` function, it accepts 3 boolean parameters
+ 1. When `true` the data will come back in the same sort order as the table is currently displaying.  When `false` the data will come back in the original sort order (pre-tablesort)
+ 2. When `true` the data will only include items that match the current filters, which will match the current table display.  When `false` all items in the table are included regarless of what is currently being filtered.
+ 3. When `true` **and pagination is enabled**, the data will only return the currently viewed page of data. When `false` data from all pages will be returned.

--- a/example-advanced.html
+++ b/example-advanced.html
@@ -44,7 +44,7 @@
 
         <hr />
 
-        <h2>Custom Filtering UI, filter function, & "no data" message</small></h2>
+        <h2>Custom Filtering UI, filter function, &amp; "no data" message</small></h2>
         <div class="row">
             <div class="col-xs-6 col-sm-4 col-sm-offset-4 col-md-3 col-md-offset-6">
                 <div class="form-group has-feedback">
@@ -190,6 +190,47 @@
             </tbody>
         </table>
 
+        <hr />
+
+        <h2>Get Table Data</h2>
+
+        <button type="button" class="btn btn-primary" ng-click="getTableData(getDataFn)">Log Table Data To Console</button>
+        <label class="checkbox-inline">
+            <input type="checkbox" ng-model="shouldApplySorting">
+            Apply Sorting
+        </label>
+        <label class="checkbox-inline">
+            <input type="checkbox" ng-model="shouldApplyFiltering">
+            Apply Filtering
+        </label>
+        <label class="checkbox-inline">
+            <input type="checkbox" ng-model="limitToCurrentPageOnly">
+            Current page only
+        </label>
+
+        <table class="table table-striped" ts-wrapper ts-item-name="product" ts-get-table-data-function="getDataFn">
+            <thead>
+                <tr>
+                    <th>Select</th>
+                    <th ts-criteria="Id" ts-filter>Id</th>
+                    <th ts-criteria="Name|lowercase" ts-filter ts-default>Name</th>
+                    <th ts-criteria="Price|parseFloat" ts-filter>Price</th>
+                    <th ts-criteria="Quantity|parseInt" ts-filter>Quantity</th>
+                </tr>
+            </thead>
+            <tbody>
+                <tr ng-repeat="item in tableSixItems track by item.Id"
+                    ng-class="{'active':item.Selected}"
+                    ts-repeat>
+                    <td><input type="checkbox" ng-model="item.Selected" /></td>
+                    <td>{{item.Id}}</td>
+                    <td>{{item.Name}}</td>
+                    <td>{{item.Price | currency}}</td>
+                    <td>{{item.Quantity}}</td>
+                </tr>
+            </tbody>
+        </table>
+
     </div>
 </div>
 
@@ -222,15 +263,17 @@
     angular
         .module( 'myApp', ['tableSort', 'ui.bootstrap'] )
         .controller( "tableTestCtrl", function tableTestCtrl($scope)  {
-          $scope.$on('tablesort:sortOrder', (event, sortOrder) => {
-            console.log('tablesort:sortOrder event', sortOrder);
-          });
+            $scope.$on('tablesort:sortOrder', (event, sortOrder) => {
+                console.log('tablesort:sortOrder event', sortOrder);
+            });
+
             //Generate some fake data
             $scope.tableOneItems = getFakeData(100);
             $scope.tableTwoItems = getFakeData(100);
             $scope.tableThreeItems = getFakeData(12);
             $scope.tableFourItems = getFakeData(100);
             $scope.tableFiveItems = getFakeData(20);
+            $scope.tableSixItems = getFakeData(25);
 
             $scope.customPerPageOptions = [20,40,60];
             $scope.customPerPageDefault = 40;
@@ -251,6 +294,15 @@
                 }
 
                 return nameMatch && priceMatch;
+            };
+
+            //Get Table Data
+            $scope.shouldApplySorting = true;
+            $scope.shouldApplyFiltering = true;
+            $scope.limitToCurrentPageOnly = false;
+            $scope.getTableData = function (getDataFn) {
+                var results = getDataFn($scope.shouldApplySorting, $scope.shouldApplyFiltering, $scope.limitToCurrentPageOnly);
+                console.log("data from table", results)
             };
         });
 

--- a/js/angular-tablesort.js
+++ b/js/angular-tablesort.js
@@ -339,6 +339,33 @@ tableSortModule.directive( 'tsWrapper', ['$parse', '$compile', function( $parse,
                 $element.after($paginationHtml);
             }
 
+            if( $attrs.tsGetTableDataFunction ) {
+                var getter = $parse($attrs.tsGetTableDataFunction);
+                var setter = getter.assign;
+                
+                //If this attribute has a value, then we want to turn it into a function on the parent scope
+                //so that it can be passed into other functions and run on the parent controllers as needed
+                var fn  = function( shouldApplySorting, shouldApplyFiltering, limitToCurrentPageOnly ) {
+                    var arr = $parse($scope.itemsArrayExpression)($scope);
+
+                    if( shouldApplySorting ) {
+                        arr = arr.sort($scope.sortFun);
+                    }
+
+                    if( shouldApplyFiltering ) {
+                        arr = $scope.filterLimitFun(arr);
+                    }
+
+                    if( limitToCurrentPageOnly ) {
+                        arr = $scope.pageLimitFun(arr);
+                    }
+
+                    return arr;
+                };
+
+                setter($scope.$parent, fn);
+            }
+
             $scope.$on( '$destroy', function() {
                 //When the directive is destroyed, also remove the filter & pagination HTML
                 if( $filterHtml ) {

--- a/js/angular-tablesort.js
+++ b/js/angular-tablesort.js
@@ -38,7 +38,7 @@ tableSortModule.directive( 'tsWrapper', ['$parse', '$compile', function( $parse,
         return templateString
             .replace(/FILTER_STRING/g, 'filtering.filterString')
             .replace(/CURRENT_PAGE_RANGE/g, 'pagination.getPageRangeString(TOTAL_COUNT)')
-            .replace(/TOTAL_COUNT/g, $scope.pagination.itemsArrayExpression + '.length')
+            .replace(/TOTAL_COUNT/g, $scope.itemsArrayExpression + '.length')
             .replace(/PER_PAGE_OPTIONS/g, 'pagination.perPageOptions')
             .replace(/ITEMS_PER_PAGE/g, 'pagination.perPage')
             .replace(/ITEM_NAME_SINGULAR/g, 'itemNameSingular')
@@ -55,7 +55,6 @@ tableSortModule.directive( 'tsWrapper', ['$parse', '$compile', function( $parse,
                 template: tableSortConfig.paginationTemplate,
                 perPageOptions: tableSortConfig.perPageOptions.concat(), //copy the array, not a reference
                 perPage: tableSortConfig.perPageDefault,
-                itemsArrayExpression: '', //this will contain the string expression for the array of items in the table
                 currentPage: 1,
                 getPageRangeString: function(total) {
                     //TODO: Format these numbers, perhaps optionally
@@ -76,6 +75,7 @@ tableSortModule.directive( 'tsWrapper', ['$parse', '$compile', function( $parse,
                 filterFields: []
             };
 
+            $scope.itemsArrayExpression = ''; //this will contain the string expression for the array of items in the table
             $scope.itemNameSingular = tableSortConfig.itemNameSingular;
             $scope.itemNamePlural = tableSortConfig.itemNamePlural;
             $scope.noDataText = tableSortConfig.noDataText;
@@ -163,8 +163,8 @@ tableSortModule.directive( 'tsWrapper', ['$parse', '$compile', function( $parse,
                 $scope.filtering.filterFields.push( expr );
             };
 
-            this.setDataForPager = function( dataArrayExp ) {
-                $scope.pagination.itemsArrayExpression = dataArrayExp;
+            this.setArrayExpr = function( dataArrayExp ) {
+                $scope.itemsArrayExpression = dataArrayExp;
             };
         }],
         link: function($scope, $element, $attrs, tsWrapperCtrl) {
@@ -434,7 +434,7 @@ tableSortModule.directive( 'tsRepeat', ['$compile', '$interpolate', function($co
             }
 
             //pass the `itemsList` from `item in itemsList` to the master directive as a string so it can be used in expressions
-            tsWrapperCtrl.setDataForPager(repeatInMatch[2]);
+            tsWrapperCtrl.setArrayExpr(repeatInMatch[2]);
 
             angular.element(element[0]).attr(ngRepeatDirective, repeatExpr);
             $compile(element, null, 1000000)(scope);

--- a/js/angular-tablesort.js
+++ b/js/angular-tablesort.js
@@ -6,17 +6,17 @@ License: MIT
 
 var tableSortModule = angular.module( 'tableSort', [] );
 
-tableSortModule.provider('tableSortConfig', function () {
-    this.filterTemplate = ""; //no filtering by default unless a template is provided
+tableSortModule.provider( 'tableSortConfig', function () {
+    this.filterTemplate = ''; //no filtering by default unless a template is provided
     this.filterFunction = null; //empty by default - use the built in filter function when left blank
-    this.paginationTemplate = ""; //no pagination by default unless a template is provided
+    this.paginationTemplate = ''; //no pagination by default unless a template is provided
     this.perPageOptions = [10, 25, 50, 100];
     this.perPageDefault = this.perPageOptions[0]; //first option by default
-    this.itemNameSingular = "item";
-    this.itemNamePlural = this.itemNameSingular + "s";
-    this.noDataText = "No " + this.itemNamePlural;
+    this.itemNameSingular = 'item';
+    this.itemNamePlural = this.itemNameSingular + 's';
+    this.noDataText = 'No ' + this.itemNamePlural;
 
-    if(!isNaN(this.perPageDefault) && this.perPageOptions.indexOf(this.perPageDefault) === -1){
+    if( !isNaN(this.perPageDefault) && this.perPageOptions.indexOf(this.perPageDefault) === -1 ) {
         //If a default per-page option was added that isn't in the array, add it and sort the array
         this.perPageOptions.push(this.perPageDefault);
     }
@@ -30,21 +30,21 @@ tableSortModule.provider('tableSortConfig', function () {
 
 });
 
-tableSortModule.directive('tsWrapper', ['$parse', '$compile', function( $parse, $compile ) {
+tableSortModule.directive( 'tsWrapper', ['$parse', '$compile', function( $parse, $compile ) {
     'use strict';
 
-    function replaceTemplateTokens($scope, templateString){
+    function replaceTemplateTokens($scope, templateString) {
         //Replace some strings with the proper expressions to be compiled
         return templateString
-            .replace(/FILTER_STRING/g, "filtering.filterString")
-            .replace(/CURRENT_PAGE_RANGE/g, "pagination.getPageRangeString(TOTAL_COUNT)")
-            .replace(/TOTAL_COUNT/g, $scope.pagination.itemsArrayExpression + ".length")
+            .replace(/FILTER_STRING/g, 'filtering.filterString')
+            .replace(/CURRENT_PAGE_RANGE/g, 'pagination.getPageRangeString(TOTAL_COUNT)')
+            .replace(/TOTAL_COUNT/g, $scope.pagination.itemsArrayExpression + '.length')
             .replace(/PER_PAGE_OPTIONS/g, 'pagination.perPageOptions')
             .replace(/ITEMS_PER_PAGE/g, 'pagination.perPage')
             .replace(/ITEM_NAME_SINGULAR/g, 'itemNameSingular')
             .replace(/ITEM_NAME_PLURAL/g, 'itemNamePlural')
-            .replace(/FILTERED_COUNT/g, "filtering.filteredCount")
-            .replace(/CURRENT_PAGE_NUMBER/g, "pagination.currentPage");
+            .replace(/FILTERED_COUNT/g, 'filtering.filteredCount')
+            .replace(/CURRENT_PAGE_NUMBER/g, 'pagination.currentPage');
     }
 
     return {
@@ -55,7 +55,7 @@ tableSortModule.directive('tsWrapper', ['$parse', '$compile', function( $parse, 
                 template: tableSortConfig.paginationTemplate,
                 perPageOptions: tableSortConfig.perPageOptions.concat(), //copy the array, not a reference
                 perPage: tableSortConfig.perPageDefault,
-                itemsArrayExpression: "", //this will contain the string expression for the array of items in the table
+                itemsArrayExpression: '', //this will contain the string expression for the array of items in the table
                 currentPage: 1,
                 getPageRangeString: function(total) {
                     //TODO: Format these numbers, perhaps optionally
@@ -64,13 +64,13 @@ tableSortModule.directive('tsWrapper', ['$parse', '$compile', function( $parse, 
                     var startPage = Math.max(($scope.pagination.currentPage - 1) * ($scope.pagination.perPage + 1), 1);
                     var endPage = Math.min($scope.pagination.currentPage * $scope.pagination.perPage, maxOnPage);
                     //This prevents the range from showing when the total number of items can be shown on a single page
-                    return $scope.filtering.filteredCount === 0 ? "" : (endPage === maxOnPage && startPage === 1 ? "" : startPage + "-") + endPage;
+                    return $scope.filtering.filteredCount === 0 ? '' : (endPage === maxOnPage && startPage === 1 ? '' : startPage + '-') + endPage;
                 }
             };
 
             $scope.filtering = {
                 template: tableSortConfig.filterTemplate,
-                filterString: "",
+                filterString: '',
                 filterFunction: tableSortConfig.filterFunction,
                 filteredCount: 0,
                 filterFields: []
@@ -89,32 +89,29 @@ tableSortModule.directive('tsWrapper', ['$parse', '$compile', function( $parse, 
             this.setSortField = function( sortexpr, element, name ) {
                 var i;
                 var expr = parse_sortexpr( sortexpr, name );
-                if( $scope.sortExpression.length === 1
-                    && $scope.sortExpression[0][0] === expr[0] ) {
+                if( $scope.sortExpression.length === 1 && $scope.sortExpression[0][0] === expr[0] ) {
                     if( $scope.sortExpression[0][2] ) {
-                        element.removeClass( "tablesort-desc" );
-                        element.addClass( "tablesort-asc" );
+                        element.removeClass( 'tablesort-desc' );
+                        element.addClass( 'tablesort-asc' );
                         $scope.sortExpression[0][2] = false;
-                    }
-                    else {
-                        element.removeClass( "tablesort-asc" );
-                        element.addClass( "tablesort-desc" );
+                    } else {
+                        element.removeClass( 'tablesort-asc' );
+                        element.addClass( 'tablesort-desc' );
                         $scope.sortExpression[0][2] = true;
                     }
-                    $scope.$emit('tablesort:sortOrder', [{
+                    $scope.$emit( 'tablesort:sortOrder', [{
                       name: $scope.sortExpression[0][3],
                       order: $scope.sortExpression[0][2]
                     }]);
-                }
-                else {
+                } else {
                     for( i=0; i<$scope.headings.length; i=i+1 ) {
                         $scope.headings[i]
-                            .removeClass( "tablesort-desc" )
-                            .removeClass( "tablesort-asc" );
+                            .removeClass( 'tablesort-desc' )
+                            .removeClass( 'tablesort-asc' );
                     }
-                    element.addClass( "tablesort-asc" );
+                    element.addClass( 'tablesort-asc' );
                     $scope.sortExpression = [expr];
-                    $scope.$emit('tablesort:sortOrder', [{
+                    $scope.$emit( 'tablesort:sortOrder', [{
                       name: expr[3],
                       order: expr[2]
                     }]);
@@ -128,24 +125,23 @@ tableSortModule.directive('tsWrapper', ['$parse', '$compile', function( $parse, 
                 for( i=0; i<$scope.sortExpression.length; i=i+1 ) {
                     if( $scope.sortExpression[i][0] === expr[0] ) {
                         if( $scope.sortExpression[i][2] ) {
-                            element.removeClass( "tablesort-desc" );
-                            element.addClass( "tablesort-asc" );
+                            element.removeClass( 'tablesort-desc' );
+                            element.addClass( 'tablesort-asc' );
                             $scope.sortExpression[i][2] = false;
-                        }
-                        else {
-                            element.removeClass( "tablesort-asc" );
-                            element.addClass( "tablesort-desc" );
+                        } else {
+                            element.removeClass( 'tablesort-asc' );
+                            element.addClass( 'tablesort-desc' );
                             $scope.sortExpression[i][2] = true;
                         }
                         toggle_order = true;
                     }
                 }
                 if( !toggle_order ) {
-                    element.addClass( "tablesort-asc" );
+                    element.addClass( 'tablesort-asc' );
                     $scope.sortExpression.push( expr );
                 }
 
-                $scope.$emit('tablesort:sortOrder', $scope.sortExpression.map(function (a) {
+                $scope.$emit( 'tablesort:sortOrder', $scope.sortExpression.map(function (a) {
                   return {
                     name: a[3],
                     order: a[2]
@@ -171,43 +167,43 @@ tableSortModule.directive('tsWrapper', ['$parse', '$compile', function( $parse, 
                 $scope.pagination.itemsArrayExpression = dataArrayExp;
             };
         }],
-        link: function($scope, $element, $attrs, tsWrapperCtrl){
+        link: function($scope, $element, $attrs, tsWrapperCtrl) {
 
-            if($attrs.tsItemName){
-                var originalNoDataText = "No " + $scope.itemNamePlural;
+            if( $attrs.tsItemName ) {
+                var originalNoDataText = 'No ' + $scope.itemNamePlural;
 
                 //if the table attributes has an item name on it, this takes priority
                 $scope.itemNameSingular = $attrs.tsItemName;
 
-                if($attrs.tsItemNamePlural){
+                if( $attrs.tsItemNamePlural ) {
                     //if a plural name was specified, use that
                     $scope.itemNamePlural = $attrs.tsItemNamePlural;
-                }else{
-                    //otherwise just add "s" to the singular name
-                    $scope.itemNamePlural = $attrs.tsItemName + "s";
+                } else {
+                    //otherwise just add 's' to the singular name
+                    $scope.itemNamePlural = $attrs.tsItemName + 's';
                 }
 
-                if(!$attrs.tsNoDataText && $scope.noDataText === originalNoDataText){
-                    //If the noDataText was NOT specified AND it's in the same "No ITEMS" format as the default , update it to contain the new item name
-                    $scope.noDataText = "No " + $scope.itemNamePlural;
+                if( !$attrs.tsNoDataText && $scope.noDataText === originalNoDataText ) {
+                    //If the noDataText was NOT specified AND it's in the same 'No ITEMS' format as the default , update it to contain the new item name
+                    $scope.noDataText = 'No ' + $scope.itemNamePlural;
                 }
             }
 
-            if($attrs.tsNoDataText){
+            if( $attrs.tsNoDataText ) {
                 //If the noDataText was specified, update it
                 $scope.noDataText = $attrs.tsNoDataText;
             }
 
             //local attribute usages of the pagination/filtering options will override the global config
-            if($attrs.tsPerPageOptions){
+            if( $attrs.tsPerPageOptions ) {
                 $scope.pagination.perPageOptions = $scope.$eval($attrs.tsPerPageOptions);
             }
 
-            if($attrs.tsPerPageDefault){
+            if( $attrs.tsPerPageDefault ) {
                 var defaultPerPage = $scope.$eval($attrs.tsPerPageDefault);
-                if(!isNaN(defaultPerPage)){
+                if( !isNaN(defaultPerPage) ) {
                     $scope.pagination.perPage = defaultPerPage;
-                    if($scope.pagination.perPageOptions.indexOf($scope.pagination.perPage) === -1){
+                    if( $scope.pagination.perPageOptions.indexOf($scope.pagination.perPage) === -1 ) {
                         //If a default per-page option was added that isn't in the array, add it and sort the array
                         $scope.pagination.perPageOptions.push($scope.pagination.perPage);
                         $scope.pagination.perPageOptions.sort(function (a,b) {return a - b;});
@@ -215,43 +211,43 @@ tableSortModule.directive('tsWrapper', ['$parse', '$compile', function( $parse, 
                 }
             }
 
-            if($attrs.tsFilterFields){
-                var filterFields = $attrs.tsFilterFields.split(",")
-                    .filter(function(item){
-                        return item && item.trim() !== "";
+            if( $attrs.tsFilterFields ) {
+                var filterFields = $attrs.tsFilterFields.split(',')
+                    .filter(function(item) {
+                        return item && item.trim() !== '';
                     });
-                for( var i=0; i<filterFields.length; i=i+1 ){
+                for( var i=0; i<filterFields.length; i=i+1 ) {
                     tsWrapperCtrl.addFilterField(filterFields[i]);
                 }
             }
 
             var $filterHtml;
-            if($attrs.tsDisplayFiltering !== "false" && $scope.filtering.template !== "" && $scope.filtering.filterFields.length>0){
+            if( $attrs.tsDisplayFiltering !== 'false' && $scope.filtering.template !== '' && $scope.filtering.filterFields.length>0 ) {
                 var filterString = replaceTemplateTokens($scope, $scope.filtering.template);
                 $filterHtml = $compile(filterString)($scope);
                 //Add filtering HTML BEFORE the table
                 $element.parent()[0].insertBefore($filterHtml[0], $element[0]);
             }
 
-            if($attrs.tsFilterFunction){
+            if( $attrs.tsFilterFunction ) {
                 //if the table attributes has a filter function on it, this takes priority
                 $scope.filtering.filterFunction = $scope.$eval($attrs.tsFilterFunction);
             }
 
-            if(!angular.isFunction($scope.filtering.filterFunction)){
+            if( !angular.isFunction($scope.filtering.filterFunction) ) {
                 //No custom filter was provided...
-                if($scope.filtering.filterFields.length===0){
+                if( $scope.filtering.filterFields.length===0 ) {
                     //There are no filter fields, so always return everything
-                    $scope.filtering.filterFunction = function(item){
+                    $scope.filtering.filterFunction = function(item) {
                         return true;
                     };
-                }else{
+                } else {
                     //This is the default filter function. It does a lowercase string match
                     $scope.filtering.filterFunction = function(item) {
                         var shouldInclude = false;
                         for( var i=0; i<$scope.filtering.filterFields.length; i=i+1 ) {
-                            if(!shouldInclude){
-                                var str = ($scope.filtering.filterFields[i][0](item) || "").toString().toLowerCase(); //parse the item's property using the `ts-criteria` value & filter
+                            if( !shouldInclude ) {
+                                var str = ($scope.filtering.filterFields[i][0](item) || '').toString().toLowerCase(); //parse the item's property using the `ts-criteria` value & filter
                                 shouldInclude = str.indexOf($scope.filtering.filterString.toLowerCase()) > -1;
                             }
                         }
@@ -260,8 +256,8 @@ tableSortModule.directive('tsWrapper', ['$parse', '$compile', function( $parse, 
                 }
             }
 
-            $scope.filterLimitFun = function(array){
-                if(!$attrs.tsFilterFunction && $scope.filtering.filterString === ""){
+            $scope.filterLimitFun = function(array) {
+                if( !$attrs.tsFilterFunction && $scope.filtering.filterString === '' ) {
                     //Return unfiltered when NOT using a custom filter function and when nothing is being searched
                     $scope.filtering.filteredCount = array.length;
                     return array;
@@ -274,7 +270,7 @@ tableSortModule.directive('tsWrapper', ['$parse', '$compile', function( $parse, 
             $scope.sortFun = function( a, b ) {
                 var i, aval, bval, descending, filterFun, compResult;
                 var collator = new Intl.Collator(undefined, {sensitivity: 'case'});
-                for( i=0; i<$scope.sortExpression.length; i=i+1 ){
+                for( i=0; i<$scope.sortExpression.length; i=i+1 ) {
                     aval = $scope.sortExpression[i][0](a);
                     bval = $scope.sortExpression[i][0](b);
                     filterFun = b[$scope.sortExpression[i][1]];
@@ -283,54 +279,52 @@ tableSortModule.directive('tsWrapper', ['$parse', '$compile', function( $parse, 
                         bval = filterFun( bval );
                     }
                     if( aval === undefined || aval === null ) {
-                        aval = "";
+                        aval = '';
                     }
                     if( bval === undefined || bval === null ) {
-                    bval = "";
+                    bval = '';
                     }
                     descending = $scope.sortExpression[i][2];
                     compResult = collator.compare(aval, bval);
                     if( compResult === 1 ) {
                         return descending ? -1 : 1;
-                    }
-                    else if( compResult === -1 ) {
+                    } else if( compResult === -1 ) {
                         return descending ? 1 : -1;
                     }
                 }
 
-                // All the sort fields were equal. If there is a "track by" expression,
+                // All the sort fields were equal. If there is a 'track by'' expression,
                 // use that as a tiebreaker to make the sort result stable.
                 if( $scope.trackBy ) {
                     aval = a[$scope.trackBy];
                     bval = b[$scope.trackBy];
                     if( aval === undefined || aval === null ) {
-                        aval = "";
+                        aval = '';
                     }
                     if( bval === undefined || bval === null ) {
-                        bval = "";
+                        bval = '';
                     }
                     compResult = collator.compare(aval, bval);
                     if( compResult === 1 ) {
                         return descending ? -1 : 1;
-                    }
-                    else if( compResult === -1 ) {
+                    } else if( compResult === -1 ) {
                         return descending ? 1 : -1;
                     }
                 }
                 return 0;
             };
 
-            $scope.pageLimitFun = function(array){
-                if($attrs.tsDisplayPagination === "false" || $scope.pagination.template === "") {
+            $scope.pageLimitFun = function(array) {
+                if( $attrs.tsDisplayPagination === 'false' || $scope.pagination.template === '') {
                     //pagination is disabled on this table or there is no template, so return everything
                     return array;
                 }
                 //Only return the items that are in the correct index range for the currently selected page
-                var begin = ($scope.pagination.currentPage-1) * $scope.pagination.perPage;
+                var begin = ($scope.pagination.currentPage - 1) * $scope.pagination.perPage;
                 var end = $scope.pagination.currentPage * $scope.pagination.perPage;
                 var final=[];
-                for(var i=0; i < array.length; i++){
-                    if(i >= begin && i < end){
+                for( var i=0; i < array.length; i++ ) {
+                    if( i >= begin && i < end ) {
                         final.push(array[i]);
                     }
                 }
@@ -338,19 +332,19 @@ tableSortModule.directive('tsWrapper', ['$parse', '$compile', function( $parse, 
             };
 
             var $paginationHtml;
-            if($attrs.tsDisplayPagination !== "false" && $scope.pagination.template !== ""){
+            if( $attrs.tsDisplayPagination !== 'false' && $scope.pagination.template !== '' ) {
                 var pagerString = replaceTemplateTokens($scope, $scope.pagination.template);
                 $paginationHtml = $compile(pagerString)($scope);
                 //Add pagination HTML AFTER the table
                 $element.after($paginationHtml);
             }
 
-            $scope.$on("$destroy", function(){
+            $scope.$on( '$destroy', function() {
                 //When the directive is destroyed, also remove the filter & pagination HTML
-                if($filterHtml){
+                if( $filterHtml ) {
                     $filterHtml.remove();
                 }
-                if($paginationHtml){
+                if( $paginationHtml ) {
                     $paginationHtml.remove();
                 }
             });
@@ -358,29 +352,28 @@ tableSortModule.directive('tsWrapper', ['$parse', '$compile', function( $parse, 
     };
 }]);
 
-tableSortModule.directive('tsCriteria', function() {
+tableSortModule.directive( 'tsCriteria', function() {
     return {
-        require: "^tsWrapper",
+        require: '^tsWrapper',
         link: function(scope, element, attrs, tsWrapperCtrl) {
             var clickingCallback = function(event) {
                 scope.$apply( function() {
                     if( event.shiftKey ) {
                         tsWrapperCtrl.addSortField(attrs.tsCriteria, element, attrs.tsName);
-                    }
-                    else {
+                    } else {
                         tsWrapperCtrl.setSortField(attrs.tsCriteria, element, attrs.tsName);
                     }
                 } );
             };
-            element.bind('click', clickingCallback);
-            element.addClass('tablesort-sortable');
-            if( "tsDefault" in attrs && attrs.tsDefault !== "0" ) {
+            element.bind( 'click', clickingCallback );
+            element.addClass( 'tablesort-sortable' );
+            if( 'tsDefault' in attrs && attrs.tsDefault !== '0' ) {
                 tsWrapperCtrl.addSortField( attrs.tsCriteria, element, attrs.tsName );
-                if( attrs.tsDefault === "descending" ) {
+                if( attrs.tsDefault === 'descending' ) {
                     tsWrapperCtrl.addSortField( attrs.tsCriteria, element, attrs.tsName );
                 }
             }
-            if( "tsFilter" in attrs) {
+            if( 'tsFilter' in attrs) {
                 tsWrapperCtrl.addFilterField( attrs.tsCriteria, element );
             }
             tsWrapperCtrl.registerHeading( element );
@@ -388,16 +381,16 @@ tableSortModule.directive('tsCriteria', function() {
     };
 });
 
-tableSortModule.directive("tsRepeat", ['$compile', '$interpolate', function($compile, $interpolate) {
+tableSortModule.directive( 'tsRepeat', ['$compile', '$interpolate', function($compile, $interpolate) {
     return {
         terminal: true,
         multiElement: true,
-        require: "^tsWrapper",
+        require: '^tsWrapper',
         priority: 1000000,
         link: function(scope, element, attrs, tsWrapperCtrl) {
-            var repeatAttrs = ["ng-repeat", "data-ng-repeat", "ng-repeat-start", "data-ng-repeat-start"];
+            var repeatAttrs = ['ng-repeat', 'data-ng-repeat', 'ng-repeat-start', 'data-ng-repeat-start'];
             var ngRepeatDirective = repeatAttrs[0];
-            var tsRepeatDirective = "ts-repeat";
+            var tsRepeatDirective = 'ts-repeat';
             for (var i = 0; i < repeatAttrs.length; i++) {
                 if (angular.isDefined(element.attr(repeatAttrs[i]))) {
                     ngRepeatDirective = repeatAttrs[i];
@@ -406,7 +399,7 @@ tableSortModule.directive("tsRepeat", ['$compile', '$interpolate', function($com
                 }
             }
 
-            var tsExpr = "tablesortOrderBy:sortFun | tablesortLimit:filterLimitFun | tablesortLimit:pageLimitFun";
+            var tsExpr = 'tablesortOrderBy:sortFun | tablesortLimit:filterLimitFun | tablesortLimit:pageLimitFun';
             var repeatExpr = element.attr(ngRepeatDirective);
             var repeatExprRegex = /^\s*([\s\S]+?)\s+in\s+([\s\S]+?)(\s+track\s+by\s+[\s\S]+?)?\s*$/;
             var trackByMatch = repeatExpr.match(/\s+track\s+by\s+\S+?\.(\S+)/);
@@ -419,11 +412,11 @@ tableSortModule.directive("tsRepeat", ['$compile', '$interpolate', function($com
             if (repeatExpr.search(/tablesort/) !== -1) {
                 repeatExpr = repeatExpr.replace(/tablesort/, tsExpr);
                 if (trackByMatch) {
-                    //Move the "track by" statement to the end
-                    repeatExpr = repeatExpr.replace(trackByMatch[0], "") + trackByMatch[0];
+                    //Move the 'track by'' statement to the end
+                    repeatExpr = repeatExpr.replace(trackByMatch[0], '') + trackByMatch[0];
                 }
             } else {
-                repeatExpr = repeatExpr.replace(repeatExprRegex, "$1 in $2 | " + tsExpr + "$3");
+                repeatExpr = repeatExpr.replace(repeatExprRegex, '$1 in $2 | ' + tsExpr + '$3');
             }
 
             if (angular.isUndefined(attrs.tsHideNoData)) {
@@ -433,9 +426,9 @@ tableSortModule.directive("tsRepeat", ['$compile', '$interpolate', function($com
                 var noDataRow = angular.element(element[0]).clone();
                 noDataRow.removeAttr(ngRepeatDirective);
                 noDataRow.removeAttr(tsRepeatDirective);
-                noDataRow.addClass("showIfLast");
+                noDataRow.addClass( 'showIfLast' );
                 noDataRow.children().remove();
-                noDataRow.append('<td colspan="' + element[0].childElementCount + '">' + startSym + 'noDataText' + endSym + '</td>');
+                noDataRow.append( '<td colspan="' + element[0].childElementCount + '">' + startSym + 'noDataText' + endSym + '</td>' );
                 noDataRow = $compile(noDataRow)(scope);
                 element.parent().prepend(noDataRow);
             }
@@ -449,14 +442,14 @@ tableSortModule.directive("tsRepeat", ['$compile', '$interpolate', function($com
     };
 }]);
 
-tableSortModule.filter( 'tablesortLimit', function(){
+tableSortModule.filter( 'tablesortLimit', function() {
     return function(array, limitFun) {
     if(!array) return;
     return limitFun(array);
     };
 } );
 
-tableSortModule.filter( 'tablesortOrderBy', function(){
+tableSortModule.filter( 'tablesortOrderBy', function() {
     return function(array, sortfun ) {
         if(!array) return;
         var arrayCopy = array.concat();
@@ -464,19 +457,19 @@ tableSortModule.filter( 'tablesortOrderBy', function(){
     };
 } );
 
-tableSortModule.filter( 'parseInt', function(){
+tableSortModule.filter( 'parseInt', function() {
     return function(input) {
         return parseInt( input ) || null;
     };
 } );
 
-tableSortModule.filter( 'parseFloat', function(){
+tableSortModule.filter( 'parseFloat', function() {
     return function(input) {
         return parseFloat( input ) || null;
     };
 } );
 
-tableSortModule.filter('parseDate', function () {
+tableSortModule.filter( 'parseDate', function () {
     return function (input) {
         var timestamp = Date.parse(input);
         return isNaN(timestamp) ? null : timestamp;

--- a/typedefs/angular-tablesort.d.ts
+++ b/typedefs/angular-tablesort.d.ts
@@ -2,8 +2,13 @@
 // Project: https://github.com/mattiash/angular-tablesort
 // Definitions by: AppRiver, LLC
 
+declare module 'angular-tablesort' {
+    export type ITableSortConfigProvider = angular.tablesort.ITableSortConfigProvider;
+    export type ITableSortGetDataFunc<T> = angular.tablesort.ITableSortGetDataFunc<T>;
+}
+
 declare namespace angular.tablesort {
-    interface ITableSortConfigProvider {
+    export interface ITableSortConfigProvider {
         /**
          * @description Provide the default function for filtering down items when models change
          * @default A lowercase string match for values defined by the ts-criteria attributes with ts-filter also on them
@@ -53,4 +58,13 @@ declare namespace angular.tablesort {
         noDataText: string;
 
     }
+
+    /**
+     * @description Return an array of items currently displayed in the table. Pass in parameters to sort and filter the returned data as needed.
+     * @param {boolean} shouldApplySorting - When  true the data will come back in the same sort order as the table is currently displaying.  When false the data will come back in the original sort order (pre-tablesort) 
+     * @param {boolean} shouldApplyFiltering - When true the data will only include items that match the current filters, which will match the current table display.  When false all items in the table are included regarless of what is currently being filtered.
+     * @param {boolean} limitToCurrentPageOnly - When true and pagination is enabled, the data will only return the currently viewed page of data. When false data from all pages will be returned.
+     * @returns {any[]} an array of items that are currently displayed in the table
+     */
+    export type ITableSortGetDataFunc<T> = (shouldApplySorting?: boolean, shouldApplyFiltering?: boolean, limitToCurrentPageOnly?: boolean) => T[];
 }


### PR DESCRIPTION
This addresses issues #74 and #62.

Now anything that might need the current view of the table data can get it when needed by calling a simple function.  

Example usage: My organization plans to use this to filter a list down, and then to be able to export that filtered list to a CSV file
