### PR TITLE
More correctly reference the TypeScript typedefs

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,10 +7,7 @@
     "type": "git",
     "url": "https://github.com/mattiash/angular-tablesort.git"
   },
-  "typescript": {
-    "definition": "typedefs/angular-tablesort.d.ts"
-  },
-  "typings": "./typedefs/angular-tablesort",
+  "types": "typedefs/angular-tablesort.d.ts",
   "license": "MIT",
   "homepage": "https://github.com/mattiash/angular-tablesort"
 }


### PR DESCRIPTION
According to this page: https://www.typescriptlang.org/docs/handbook/declaration-files/publishing.html
The `package.json` file should use the `types` property to point at the typedef file.  In my previous PR where I made the typedefs, I incorrectly used the wrong property and also pointed at the folder instead of the file.