### PR TITLE
Final fix to the typedefs path

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,8 @@
     "type": "git",
     "url": "https://github.com/mattiash/angular-tablesort.git"
   },
-  "types": "typedefs/angular-tablesort.d.ts",
+  "types": "./typedefs/angular-tablesort.d.ts",
+  "typings": "./typedefs/angular-tablesort.d.ts",
   "license": "MIT",
   "homepage": "https://github.com/mattiash/angular-tablesort"
 }


### PR DESCRIPTION
sorry about all these changes for this one thing.  This is what I get for not testing things.

The reason for the change now is that the `types` property is used by TypeScript 2.x's `@types` stuff to automatically find the typedefs, but people on TypeScript 1.x still need to use the 3rd party `typings` tool.  To satisfy both use cases, we can just reference both properties.

This time I tested it locally and this change worked.