### PR TITLE
New option to wrap the table with an element

### DIFF
--- a/README.md
+++ b/README.md
@@ -156,16 +156,17 @@ Configuring Global Options
 Several options may be configured globally per-app.
 
 
-| Property           | Type              | Default                | Description |
+| Property             | Type              | Default                | Description |
 |--------------------|-------------------|------------------------|-------------|
-|`filterTemplate`    |`string`           |`""`                    |HTML string template for filtering the table. _This will be included **before** the element with `ts-wrapper` specified on it._  See example above.|
+|`filterTemplate`      |`string`           |`""`                    |HTML string template for filtering the table. _This will be included **before** the element with `ts-wrapper` specified on it._  See example above.|
 |`filterFunction`    |`function`         |`null`                  |A function that will be called for every item being iterated over in the table. This function will be passed the object being iterated over as the first parameter. It should return a `boolean` value as to include the item or not.  _(This can be overridden per-table)_|
-|`itemNameSingular`  |`string`           |`"item"`                |The default singular version of the name for the items being iterated over. _(This can be overridden per-table)_|
-|`itemNamePlural`    |`string`           |`itemNameSingular + "s"`|The default plural version of the name for the items being iterated over. This just appends `"s"` to the singular name, which should work for most words in English. _(This can be overridden per-table)_|
+|`itemNameSingular`    |`string`           |`"item"`                |The default singular version of the name for the items being iterated over. _(This can be overridden per-table)_|
+|`itemNamePlural`      |`string`           |`itemNameSingular + "s"`|The default plural version of the name for the items being iterated over. This just appends `"s"` to the singular name, which should work for most words in English. _(This can be overridden per-table)_|
 |`noDataText`        |`string`           |`"No " + itemNamePlural`|The text that displays in the `.showIfLast` cell shown when a table is empty|
-|`paginationTemplate`|`string`           |`""`                    |HTML string template for paging the table. _This will be included **after** the element with `ts-wrapper` specified on it._ See example above.|
-|`perPageOptions`    |`array` of `number`|`[10, 25, 50, 100]`     |The options for how many items to show on each page of results.  _(This can be overridden per-table)_|
-|`perPageDefault`    |`number`           |`perPageOptions[0]`     |The default number of items for show on each page of results. By default, it picks the first item in the `perPageOptions` array.  _(This can be overridden per-table)_|
+|`wrappingElementClass`|`string`           |`""`                    |The the default CSS class to be applied to an element that will wrap the `<table>` element only. If left blank, no element will wrap the table.   _(This can be overridden per-table)_|
+|`paginationTemplate`  |`string`           |`""`                    |HTML string template for paging the table. _This will be included **after** the element with `ts-wrapper` specified on it._ See example above.|
+|`perPageOptions`      |`array` of `number`|`[10, 25, 50, 100]`     |The options for how many items to show on each page of results.  _(This can be overridden per-table)_|
+|`perPageDefault`      |`number`           |`perPageOptions[0]`     |The default number of items for show on each page of results. By default, it picks the first item in the `perPageOptions` array.  _(This can be overridden per-table)_|
 
 Here's an example of how to change an option
 ```js
@@ -173,6 +174,7 @@ angular
     .module('myApp')
     .config(['tableSortConfigProvider', function(tableSortConfigProvider){
         tableSortConfigProvider.noDataText = "This table has nothing to show!";
+        tableSortConfigProvider.wrappingElementClass = "table-reponsive";
     }
 ]);
 ```
@@ -340,7 +342,19 @@ $scope.customFilterFn = function(item){
 </table>
 ```
 
-###Getting Data Out of the Table
+##Wrapping The Table Element
+
+Certain libraries like Bootstrap allow for tables to become responsive when at a smaller screen size by wrapping it in a `table-reponsive` class.  If this is desired on a table using angular-tablesort this can become and issue if the filtering or pagination are used since they will also be inside of this wrapping element, which will cause some display issues.
+
+This can be configured globally with the `wrappingElementClass` configuration option, or per-table with the `ts-wrapping-element-class` attribute
+
+```html
+
+<table ts-wrapper ts-wrapping-element-class="table-reponsive">
+```
+
+
+##Getting Data Out of the Table
 
 To get the current view of the data in the table, pass something to the `ts-get-table-data-function` attribute.  Whatever is passed in will be converted into a function.
 That function can then be passed as a parameter to a click event function, or anything else.  Within the controller, just run that function and it will return the data in the table.

--- a/README.md
+++ b/README.md
@@ -131,7 +131,7 @@ $scope.$on('tablesort:sortOrder', (event, sortOrder) => {
  CSS
 ---
 
-All table headings that can be sorted on is styled with css-class `tablesort-sortable`. The table headings that the table is currently sorted on is styled with `tablesort-asc` or `tablesort-desc` classes depending on the sort-direction. A stylesheet is included to show that it works, but you probably want to build your own.
+All table headings that can be sorted on is styled with the css class `tablesort-sortable`. The table headings that the table is currently sorted on is styled with `tablesort-asc` or `tablesort-desc` classes depending on the sort-direction. A stylesheet is included to show that it works, but you probably want to build your own.
 
 
 Empty Tables
@@ -157,12 +157,12 @@ Several options may be configured globally per-app.
 
 
 | Property             | Type              | Default                | Description |
-|--------------------|-------------------|------------------------|-------------|
+|----------------------|-------------------|------------------------|-------------|
 |`filterTemplate`      |`string`           |`""`                    |HTML string template for filtering the table. _This will be included **before** the element with `ts-wrapper` specified on it._  See example above.|
-|`filterFunction`    |`function`         |`null`                  |A function that will be called for every item being iterated over in the table. This function will be passed the object being iterated over as the first parameter. It should return a `boolean` value as to include the item or not.  _(This can be overridden per-table)_|
+|`filterFunction`      |`function`         |`undefined`             |A function that will be called for every item being iterated over in the table. This function will be passed the object being iterated over as the first parameter. It should return a `boolean` value as to include the item or not.  _(This can be overridden per-table)_|
 |`itemNameSingular`    |`string`           |`"item"`                |The default singular version of the name for the items being iterated over. _(This can be overridden per-table)_|
 |`itemNamePlural`      |`string`           |`itemNameSingular + "s"`|The default plural version of the name for the items being iterated over. This just appends `"s"` to the singular name, which should work for most words in English. _(This can be overridden per-table)_|
-|`noDataText`        |`string`           |`"No " + itemNamePlural`|The text that displays in the `.showIfLast` cell shown when a table is empty|
+|`noDataText`          |`string`           |`"No " + itemNamePlural`|The text that displays in the `.showIfLast` cell shown when a table is empty.   _(This can be overridden per-table)_|
 |`wrappingElementClass`|`string`           |`""`                    |The the default CSS class to be applied to an element that will wrap the `<table>` element only. If left blank, no element will wrap the table.   _(This can be overridden per-table)_|
 |`paginationTemplate`  |`string`           |`""`                    |HTML string template for paging the table. _This will be included **after** the element with `ts-wrapper` specified on it._ See example above.|
 |`perPageOptions`      |`array` of `number`|`[10, 25, 50, 100]`     |The options for how many items to show on each page of results.  _(This can be overridden per-table)_|
@@ -376,5 +376,5 @@ $scope.getTableData = function (getDataFn) {
 
 When running the `getDataFn` function, it accepts 3 boolean parameters
  1. When `true` the data will come back in the same sort order as the table is currently displaying.  When `false` the data will come back in the original sort order (pre-tablesort)
- 2. When `true` the data will only include items that match the current filters, which will match the current table display.  When `false` all items in the table are included regarless of what is currently being filtered.
+ 2. When `true` the data will only include items that match the current filters, which will match the current table display.  When `false` all items in the table are included regardless of what is currently being filtered.
  3. When `true` **and pagination is enabled**, the data will only return the currently viewed page of data. When `false` data from all pages will be returned.

--- a/js/angular-tablesort.js
+++ b/js/angular-tablesort.js
@@ -7,21 +7,23 @@ License: MIT
 var tableSortModule = angular.module( 'tableSort', [] );
 
 tableSortModule.provider( 'tableSortConfig', function () {
-    this.filterTemplate = ''; //no filtering by default unless a template is provided
-    this.filterFunction = null; //empty by default - use the built in filter function when left blank
-    this.paginationTemplate = ''; //no pagination by default unless a template is provided
-    this.perPageOptions = [10, 25, 50, 100];
-    this.perPageDefault = this.perPageOptions[0]; //first option by default
-    this.itemNameSingular = 'item';
-    this.itemNamePlural = this.itemNameSingular + 's';
-    this.noDataText = 'No ' + this.itemNamePlural;
+    this.filterTemplate = '';                          //No filtering by default unless a template is provided
+    this.filterFunction = undefined;                   //Empty by default - use the built in filter function when left blank
+    this.paginationTemplate = '';                      //No pagination by default unless a template is provided
+    
+    //The below options can all be overridden on a per-table basis
+    this.perPageOptions = [10, 25, 50, 100];           //Default pagination options
+    this.perPageDefault = this.perPageOptions[0];      //Select the first option by default
+    this.itemNameSingular = 'item';                    //Default name
+    this.itemNamePlural = this.itemNameSingular + 's'; //Default way to make an item plural for English
+    this.noDataText = 'No ' + this.itemNamePlural;     //Default text to show that there are no items
 
     if( !isNaN(this.perPageDefault) && this.perPageOptions.indexOf(this.perPageDefault) === -1 ) {
-        //If a default per-page option was added that isn't in the array, add it and sort the array
+        //If a default per-page option was added that isn't in the array, add it at the end
         this.perPageOptions.push(this.perPageDefault);
     }
 
-    //Sort the array
+    //Sort the per-page options array
     this.perPageOptions.sort(function (a,b) {return a - b;});
 
     this.$get = function () {

--- a/js/angular-tablesort.js
+++ b/js/angular-tablesort.js
@@ -17,6 +17,7 @@ tableSortModule.provider( 'tableSortConfig', function () {
     this.itemNameSingular = 'item';                    //Default name
     this.itemNamePlural = this.itemNameSingular + 's'; //Default way to make an item plural for English
     this.noDataText = 'No ' + this.itemNamePlural;     //Default text to show that there are no items
+    this.wrappingElementClass = "";                    //Empty by default
 
     if( !isNaN(this.perPageDefault) && this.perPageOptions.indexOf(this.perPageDefault) === -1 ) {
         //If a default per-page option was added that isn't in the array, add it at the end
@@ -116,6 +117,7 @@ tableSortModule.directive( 'tsWrapper', ['$parse', '$compile', function( $parse,
             $scope.itemNameSingular = tableSortConfig.itemNameSingular;
             $scope.itemNamePlural = tableSortConfig.itemNamePlural;
             $scope.noDataText = tableSortConfig.noDataText;
+            $scope.wrappingElementClass = tableSortConfig.wrappingElementClass;
             $scope.sortExpression = [];
             $scope.headings = [];
 
@@ -229,6 +231,11 @@ tableSortModule.directive( 'tsWrapper', ['$parse', '$compile', function( $parse,
             if( $attrs.tsNoDataText ) {
                 //If the noDataText was specified, update it
                 $scope.noDataText = $attrs.tsNoDataText;
+            }
+
+            if( $attrs.tsWrappingElementClass ) {
+                //If the wrappingElementClass was specified, update it
+                $scope.wrappingElementClass = $attrs.tsWrappingElementClass;
             }
 
             //local attribute usages of the pagination/filtering options will override the global config
@@ -375,6 +382,12 @@ tableSortModule.directive( 'tsWrapper', ['$parse', '$compile', function( $parse,
                 $element.after($paginationHtml);
             }
 
+             var $wrappingElement;
+            if( $scope.wrappingElementClass && $scope.wrappingElementClass !== "" ) {
+                //This should happen AFTER the filtering and pagination HTML are set
+                $wrappingElement = $element.wrap("<div class='"+ $scope.wrappingElementClass +"' />");
+            }
+
             if( $attrs.tsGetTableDataFunction ) {
                 var getter = $parse($attrs.tsGetTableDataFunction);
                 var setter = getter.assign;
@@ -409,6 +422,10 @@ tableSortModule.directive( 'tsWrapper', ['$parse', '$compile', function( $parse,
                 }
                 if( $paginationHtml ) {
                     $paginationHtml.remove();
+                }
+                if( $wrappingElement ) {
+                    //un-wrap the table from this element
+                    $wrappingElement.replaceWith($element);
                 }
             });
         }

--- a/typedefs/angular-tablesort.d.ts
+++ b/typedefs/angular-tablesort.d.ts
@@ -57,6 +57,12 @@ declare namespace angular.tablesort {
          */
         noDataText: string;
 
+        /**
+         * @description Provide the default CSS class to be applied to an element that will wrap the `<table>` element only. If left blank, no element will wrap the table.
+         * @default ""
+         */
+        wrappingElementClass: string;
+
     }
 
     /**


### PR DESCRIPTION
Certain libraries like Bootstrap allow for tables to become responsive when at a smaller screen size by wrapping it in a `table-reponsive` class.  If this is desired on a table using angular-tablesort this can become and issue if the filtering or pagination are used since they will also be inside of this wrapping element, which will cause some display issues.
 
This PR allows this to be configured globally with the `wrappingElementClass` configuration option, or per-table with the `ts-wrapping-element-class` attribute