### PR TITLE
use .on instead of .bind

### DIFF
--- a/js/angular-tablesort.js
+++ b/js/angular-tablesort.js
@@ -450,7 +450,7 @@ tableSortModule.directive( 'tsCriteria', function() {
                     }
                 } );
             };
-            element.bind( 'click', clickingCallback );
+            element.on('click', clickingCallback );
             element.addClass( 'tablesort-sortable' );
             if( 'tsDefault' in attrs && attrs.tsDefault !== '0' ) {
                 tsWrapperCtrl.addSortField( attrs.tsCriteria, element, attrs.tsName, scope.tsOrderBy );

--- a/js/angular-tablesort.js
+++ b/js/angular-tablesort.js
@@ -450,7 +450,7 @@ tableSortModule.directive( 'tsCriteria', function() {
                     }
                 } );
             };
-            element.on('click', clickingCallback );
+            element[element.on ? 'on' : 'bind']('click', clickingCallback );
             element.addClass( 'tablesort-sortable' );
             if( 'tsDefault' in attrs && attrs.tsDefault !== '0' ) {
                 tsWrapperCtrl.addSortField( attrs.tsCriteria, element, attrs.tsName, scope.tsOrderBy );


### PR DESCRIPTION
I have been getting a Javascript exception `element.bind is not defined` in my Angular app. But only in Firefox and only in the bundled production version.

I eventually tracked the issue down to this line. After I changed the `.bind` to `.on` the error went away.

`element.bind` is deprecated in Angular: https://docs.angularjs.org/api/ng/function/angular.element
