### PR TITLE
ADA Compliance: Added keypress functionality

### DIFF
--- a/js/angular-tablesort.js
+++ b/js/angular-tablesort.js
@@ -450,7 +450,16 @@ tableSortModule.directive( 'tsCriteria', function() {
                     }
                 } );
             };
+            // Add a callback method that can be triggered by keyboard press of Enter or Space in order to
+            // make this module more ADA compliant
+            var keypressCallback = function(event) {
+                scope.$apply( function() {
+                    if (event.which === 13 || event.which === 32) //check whether space or enter was pressed
+                        tsWrapperCtrl.setSortField(attrs.tsCriteria, element, attrs.tsName, scope.tsOrderBy);
+                } );
+            };
             element[element.on ? 'on' : 'bind']('click', clickingCallback );
+            element[element.on ? 'on' : 'bind']('keypress', keypressCallback ); //Add event handler for keypress call back
             element.addClass( 'tablesort-sortable' );
             if( 'tsDefault' in attrs && attrs.tsDefault !== '0' ) {
                 tsWrapperCtrl.addSortField( attrs.tsCriteria, element, attrs.tsName, scope.tsOrderBy );


### PR DESCRIPTION
In order for the keyboard to be able to tab to the headers, you should add a tabindex of zero to each header. For example:

<code>

            <tr>
                <th scope="col" tabindex="0" aria-label="Sort by User Name" ts-criteria="username">User Name</th>
                <th scope="col" tabindex="0" aria-label="Sort by Prefix" class="mini-field" ts-criteria="name.prefix">Prefix</th>
                <th scope="col" tabindex="0" aria-label="Sort by First Name" ts-criteria="name.firstName">First Name</th>
                <th scope="col" tabindex="0" aria-label="Sort by Middle Name" class="mini-field" ts-criteria="name.middleName">Middle</th>
                <th scope="col" tabindex="0" aria-label="Sort by Last Name" ts-criteria="name.lastName">Last Name</th>
                <th scope="col" class="action-buttons">Action</th>
            </tr>
</code>`