### PR TITLE
Add attribute to disable sorting

### DIFF
--- a/js/angular-tablesort.js
+++ b/js/angular-tablesort.js
@@ -508,9 +508,9 @@ tableSortModule.directive( 'tsRepeat', ['$compile', '$interpolate', function($co
                 }
             }
 
-            var tsExpr = 'tablesortOrderBy:sortFun | tablesortLimit:filterLimitFun | tablesortLimit:pageLimitFun';
-            if (!angular.isUndefined(attrs.tsNoSort)){
-                tsExpr = 'tablesortLimit:filterLimitFun | tablesortLimit:pageLimitFun';
+            var tsExpr = 'tablesortLimit:filterLimitFun | tablesortLimit:pageLimitFun';
+            if (angular.isUndefined(attrs.tsNoSort)){
+                tsExpr = 'tablesortOrderBy:sortFun | ' + tsExpr;
             }
             var repeatExpr = element.attr(ngRepeatDirective);
             var repeatExprRegex = /^\s*([\s\S]+?)\s+in\s+([\s\S]+?)(\s+track\s+by\s+[\s\S]+?)?\s*$/;

--- a/js/angular-tablesort.js
+++ b/js/angular-tablesort.js
@@ -509,6 +509,9 @@ tableSortModule.directive( 'tsRepeat', ['$compile', '$interpolate', function($co
             }
 
             var tsExpr = 'tablesortOrderBy:sortFun | tablesortLimit:filterLimitFun | tablesortLimit:pageLimitFun';
+            if (!angular.isUndefined(attrs.tsNoSort)){
+                tsExpr = 'tablesortLimit:filterLimitFun | tablesortLimit:pageLimitFun';
+            }
             var repeatExpr = element.attr(ngRepeatDirective);
             var repeatExprRegex = /^\s*([\s\S]+?)\s+in\s+([\s\S]+?)(\s+track\s+by\s+[\s\S]+?)?\s*$/;
             var trackByMatch = repeatExpr.match(/\s+track\s+by\s+\S+?\.(\S+)/);


### PR DESCRIPTION
This addresses an issue that exists today where the table is not sorted correctly.  The following conditions must be met for this to occur:
1. None of the table headers contain the ts-criteria attribute
2. Chrome is the browser
3. There are more than 10 items in the array

When none of the table headers contain the ts-criteria attribute, I would expect the order of the items in the array to remain unchanged.  However, that is not the case.   Here is a plunk to reproduce the issue as well as the fix that I am submitting with this PR.

https://run.plnkr.co/plunks/vnpmSm/

The fix I am proposing introduces a new attribute that explicitly tells the directive not to perform the sort.

This is useful in cases where you may want to take advantage of only the paging and filtering capabilities of this directive.