### PR TITLE
Fixed custom comparison not behaving as Array.prototype.sort compareFunction

### DIFF
--- a/js/angular-tablesort.js
+++ b/js/angular-tablesort.js
@@ -342,13 +342,13 @@ tableSortModule.directive( 'tsWrapper', ['$parse', '$compile', function( $parse,
                         aval = '';
                     }
                     if( bval === undefined || bval === null ) {
-                    bval = '';
+                        bval = '';
                     }
                     descending = $scope.sortExpression[i][2];
                     compResult = ($scope.sortExpression[i][4] || defaultComparer)(aval, bval);
-                    if( compResult === 1 ) {
+                    if( compResult > 0 ) {
                         return descending ? -1 : 1;
-                    } else if( compResult === -1 ) {
+                    } else if( compResult < 0 ) {
                         return descending ? 1 : -1;
                     }
                 }
@@ -371,9 +371,9 @@ tableSortModule.directive( 'tsWrapper', ['$parse', '$compile', function( $parse,
                         bval = '';
                     }
                     compResult = defaultComparer(aval, bval);
-                    if( compResult === 1 ) {
+                    if( compResult > 0 ) {
                         return descending ? -1 : 1;
-                    } else if( compResult === -1 ) {
+                    } else if( compResult < 0 ) {
                         return descending ? 1 : -1;
                     }
                 }


### PR DESCRIPTION
The return value of the `compareFunction` described in [MDN](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/sort) can be _less than 0_ or _greater than 0_, it does not necessary have to be exactly -1 or 1.

This is consistent with the behavior of the comparing functions of many other programming languages, and allows returning simply the difference `a - b` when the comparing elements are numbers.

See also [this discussion](https://stackoverflow.com/questions/6567941/how-does-sort-function-work-in-javascript-along-with-compare-function) on stackoverflow.

