### PR TITLE
Return 0 instead of null in number filters (unless the value is NaN)

### DIFF
--- a/js/angular-tablesort.js
+++ b/js/angular-tablesort.js
@@ -574,13 +574,15 @@ tableSortModule.filter( 'tablesortOrderBy', function() {
 
 tableSortModule.filter( 'parseInt', function() {
     return function(input) {
-        return parseInt( input ) || null;
+        var i = parseInt( input );
+        return isNaN( i ) ? null : i;
     };
 } );
 
 tableSortModule.filter( 'parseFloat', function() {
     return function(input) {
-        return parseFloat( input ) || null;
+        var f = parseFloat( input );
+        return isNaN( f ) ? null : f;
     };
 } );
 


### PR DESCRIPTION
I'm having issues sorting with negative numbers, both integers and floats. The parseInt and parseFloat filters are returning 'null' instead of zero, so zero values are separated from the non-zero values.

Instead of

-4
-2
0
0
1
3

I get

0
0
-4
-2
1
3