### PR TITLE
Fix missed $scope in ts-criteria  (issue #96)

### DIFF
--- a/js/angular-tablesort.js
+++ b/js/angular-tablesort.js
@@ -331,8 +331,8 @@ tableSortModule.directive( 'tsWrapper', ['$parse', '$compile', function( $parse,
             $scope.sortFun = function( a, b ) {
                 var i, aval, bval, descending, filterFun, compResult;
                 for( i=0; i<$scope.sortExpression.length; i=i+1 ) {
-                    aval = $scope.sortExpression[i][0](a);
-                    bval = $scope.sortExpression[i][0](b);
+                    aval = $scope.sortExpression[i][0](a, $scope);
+                    bval = $scope.sortExpression[i][0](b, $scope);
                     filterFun = b[$scope.sortExpression[i][1]];
                     if( filterFun ) {
                         aval = filterFun( aval );


### PR DESCRIPTION
Fix for #96

`sortFun` doesn't pass `$scope` to the result of parsing `ts-criteria` expression which makes impossible to use variables from the scope as part of sort expression.
