### PR TITLE
Reset currentPage when pageSize is updated

### DIFF
--- a/js/angular-tablesort.js
+++ b/js/angular-tablesort.js
@@ -104,6 +104,11 @@ tableSortModule.directive( 'tsWrapper', ['$parse', '$compile', function( $parse,
                     return $scope.filtering.filteredCount === 0 ? '' : (endPage === maxOnPage && startPage === 1 ? '' : startPage + '-') + endPage;
                 }
             };
+            $scope.$watch('pagination.perPage', function(newValue, oldValue) {
+                if (newValue != oldValue) {
+                    $scope.pagination.currentPage = 1;
+                }
+            });
 
             $scope.filtering = {
                 template: tableSortConfig.filterTemplate,


### PR DESCRIPTION
This patch resets `pagination.currentPage` whenever `pagination.pageSize` is updated. This is useful in situations like this:

1. Given that there are several pages in the table and the current page size is not the max possible
2. When you select the last page
3. And when you increase the current page size
4. without this patch, then there would be no items visible in the table. With this patch, then the first page with the new page size would be displayed.